### PR TITLE
docs: update JetBrains and VSCode installation guides with private and public server

### DIFF
--- a/docs/installation/jetbrains_installation_guide.md
+++ b/docs/installation/jetbrains_installation_guide.md
@@ -48,38 +48,69 @@
  ![jetbrains_guide_4.png](../../resources/images/jetbrains_guide_4.png)
 
 - Create or update the file to look like this:
-
-```json{
-	"servers": {
-		"defect-solver": {
-			"url": "http://0.0.0.0:8000/mcp/",
-           "type": "http",
-
-           "headers": {
-
-               "DS-API-Key": "${input:defect-solver-api-key}"
-
-           }
-	},
-	   "inputs": [
-
-           {
-
-               "type": "promptString",
-
-               "id": "defect-solver-api-key",
-
-               "description": "Enter your Defect Solver API Key",
-
-               "password": true
-
-           }
-
-   ]   
-
+  * If you are using **private MCP server** hosted on Hugging Face Space:
+  
+```json
+{
+    "servers": {        
+        "ds": {
+            "url": "https://dnext-ds-mcp-server.hf.space/mcp/",
+            "type": "http",
+            "headers": {
+                "DS-API-Key": "${input:defect-solver-api-key}",
+                "Authorization": "Bearer ${input:hf-access-token}"
+            }
+        }
+    },
+    "inputs": [
+        {
+            "type": "promptString",
+            "id": "defect-solver-api-key",
+            "description": "Enter your Defect Solver API Key",
+            "password": true
+        },
+        {
+            "type": "promptString",
+            "id": "hf-access-token",
+            "description": "Enter your Hugging Face Access Token",
+            "password": true  
+        }
+    ]
 }
-}
+
 ```
+You need to enter defect-solver-api-key and hf-access-token as inputs.
+
+  * If you are using a **public MCP server** hosted on Hugging Face Space:
+
+
+
+
+```json
+{
+    "servers": {
+        "ds": {
+            "url": "https://dnext-ds-mcp-server.hf.space/mcp/",
+            "type": "http",
+            "headers": {
+                "DS-API-Key": "${input:defect-solver-api-key}"
+            }
+        }
+    },
+    "inputs": [
+        {
+            "type": "promptString",
+            "id": "defect-solver-api-key",
+            "description": "Enter your Defect Solver API Key",
+            "password": true
+        }
+    ]
+}
+```   
+You only need to enter defect-solver-api-key as input.
+- If you are using local MCP server, you can replace the URL with your local server endpoint (e.g. http://0.0.0.0:8000/mcp)  and remove the headers section.
+
+
 - Make sure to replace the URL with your MCP server endpoint and add your API key.
 - After saving mcp.json, tools under your MCP server (e.g., defect_solver) will appear in the tools panel in chat.
 

--- a/docs/installation/vscode_installation_guide.md
+++ b/docs/installation/vscode_installation_guide.md
@@ -83,37 +83,69 @@
 - Ensure it contains the correct server URL and ID.
 - You can also add an API key for authentication.
 - It should look something like this:
-```json{
-	"servers": {
-		"defect-solver": {
-			"url": "http://0.0.0.0:8000/mcp/",
-           "type": "http",
 
-           "headers": {
-
-               "DS-API-Key": "${input:defect-solver-api-key}"
-
-           }
-	},
-	   "inputs": [
-
-           {
-
-               "type": "promptString",
-
-               "id": "defect-solver-api-key",
-
-               "description": "Enter your Defect Solver API Key",
-
-               "password": true
-
-           }
-
-   ]   
-
+  * If you are using **private MCP server** hosted on Hugging Face Space:
+  
+```json
+{
+    "servers": {        
+        "ds": {
+            "url": "https://dnext-ds-mcp-server.hf.space/mcp/",
+            "type": "http",
+            "headers": {
+                "DS-API-Key": "${input:defect-solver-api-key}",
+                "Authorization": "Bearer ${input:hf-access-token}"
+            }
+        }
+    },
+    "inputs": [
+        {
+            "type": "promptString",
+            "id": "defect-solver-api-key",
+            "description": "Enter your Defect Solver API Key",
+            "password": true
+        },
+        {
+            "type": "promptString",
+            "id": "hf-access-token",
+            "description": "Enter your Hugging Face Access Token",
+            "password": true  
+        }
+    ]
 }
-}
+
 ```
+You need to enter defect-solver-api-key and hf-access-token as inputs.
+
+  * If you are using a **public MCP server** hosted on Hugging Face Space:
+
+
+
+
+```json
+{
+    "servers": {
+        "ds": {
+            "url": "https://dnext-ds-mcp-server.hf.space/mcp/",
+            "type": "http",
+            "headers": {
+                "DS-API-Key": "${input:defect-solver-api-key}"
+            }
+        }
+    },
+    "inputs": [
+        {
+            "type": "promptString",
+            "id": "defect-solver-api-key",
+            "description": "Enter your Defect Solver API Key",
+            "password": true
+        }
+    ]
+}
+```   
+You only need to enter defect-solver-api-key as input.
+- If you are using local MCP server, you can replace the URL with your local server endpoint (e.g. http://0.0.0.0:8000/mcp)  and remove the headers section.
+
 
 ## 12. Ensure MCP Server is Running
 


### PR DESCRIPTION
This pull request updates the installation guides for JetBrains and VS Code to provide clearer instructions for configuring different types of MCP servers (private, public, and local). It introduces specific examples for each server type and clarifies the required inputs.

### Documentation Updates for MCP Server Configuration:

* **JetBrains Installation Guide (`docs/installation/jetbrains_installation_guide.md`):**
  - Added separate configuration examples for private MCP servers (with `hf-access-token`), public MCP servers (without `hf-access-token`), and local MCP servers (with customizable URLs and no headers).
  - Clarified the required inputs for each server type and provided additional instructions for replacing URLs and headers.

* **VS Code Installation Guide (`docs/installation/vscode_installation_guide.md`):**
  - Included detailed configuration examples for private MCP servers (with `hf-access-token`), public MCP servers (without `hf-access-token`), and local MCP servers (with customizable URLs and no headers).
  - Enhanced descriptions of the inputs needed for each server type and added guidance for customizing the configuration. public MCP server configuration details